### PR TITLE
Fix(responsividade): Corrigir sobreposição entre botões de paginação, responsividade geral e botão de cadastrar item

### DIFF
--- a/web/src/components/Button-Add-Found.vue
+++ b/web/src/components/Button-Add-Found.vue
@@ -1,14 +1,19 @@
 <template>
   <router-link to="/register-found">
     <button
-      class="fixed right-0 bottom-28 rounded-l-xl custom-360:w-40 custom-360:h-12 w-48 h-14 sm:w-64 sm:h-16 md:w-80 md:h-20 cursor-pointer flex items-center border border-laranja bg-laranja group hover:bg-laranja active:bg-laranja active:border-laranja"
+      class="fixed right-0 bottom-28 rounded-l-xl custom-360:w-40 custom-360:h-12 w-48 h-14 sm:w-64 sm:h-16 md:w-80 md:h-20 cursor-pointer flex items-center border border-laranja bg-laranja group hover:bg-laranja active:bg-laranja active:border-laranja
+      w-[220px] h-14 text-lg gap-2
+      sm:w-[180px] sm:h-12 sm:text-base
+      min-[400px]:w-[180px] min-[400px]:h-12 min-[400px]:text-base
+      min-[360px]:w-[140px] min-[360px]:h-10 min-[360px]:text-sm
+      max-[400px]:w-14 max-[400px]:h-14 max-[400px]:text-2xl"
       :class="{ visible: isVisible, invisible: !isVisible }"
     >
       <span
         class="text-azul font-inter font-semibold text-xs sm:text-lg ml-4 sm:ml-12 transform group-hover:translate-x-0"
       >
-        <span class="block lg:hidden">Adicionar achado</span>
-        <span class="hidden lg:block">Adicionar item achado</span>
+        <span class="block max-[769px]:block min-[770px]:hidden">Adicionar achado</span>
+        <span class="hidden min-[770px]:block">Adicionar item achado</span>
       </span>
       <span
         class="absolute right-0 h-12 w-10 sm:h-16 sm:w-10 md:h-20 md:w-10 rounded-xl bg-laranja flex items-center justify-center transform group-hover:translate-x-0 group-hover:w-full transition-all duration-300"
@@ -79,20 +84,28 @@ export default {
   .lg\:block { display: block !important; }
   .lg\:hidden { display: none !important; }
 }
-@media (max-width: 359px) {
+@media (max-width: 399px) {
   button {
-    width: 10rem !important;
-    height: 2.5rem !important;
+    width: 64px !important;
+    height: 64px !important;
+    font-size: 2.2rem !important;
+    padding: 0 !important;
   }
-  .text-xs, .sm\:text-lg {
-    font-size: 0.75rem !important;
-    line-height: 1rem !important;
-    margin-left: 0.5rem !important;
+  .text-azul, .font-inter, .font-semibold, .text-xs, .sm\:text-lg, .ml-4, .sm\:ml-12 {
+    display: none !important;
   }
-  .h-12, .sm\:h-16 { height: 2.5rem !important; }
-  .w-10, .sm\:w-10 { width: 2.5rem !important; }
-  .mr-4, .sm\:mr-10 { margin-right: 0.5rem !important; }
-  .w-6, .sm\:w-8 { width: 1.25rem !important; }
-  .h-6, .sm\:h-8 { height: 1.25rem !important; }
+  .absolute.right-0 {
+    position: static !important;
+    margin: 0 auto !important;
+    width: 100% !important;
+    height: 100% !important;
+    justify-content: center !important;
+    align-items: center !important;
+  }
+  img {
+    margin: 0 !important;
+    width: 2.2rem !important;
+    height: 2.2rem !important;
+  }
 }
 </style>

--- a/web/src/components/Button-Add-Found.vue
+++ b/web/src/components/Button-Add-Found.vue
@@ -1,17 +1,19 @@
 <template>
   <router-link to="/register-found">
     <button
-      class="fixed right-0 bottom-28 rounded-l-xl w-80 h-20 cursor-pointer flex items-center border border-laranja bg-laranja group hover:bg-laranja active:bg-laranja active:border-laranja"
+      class="fixed right-0 bottom-28 rounded-l-xl custom-360:w-40 custom-360:h-12 w-48 h-14 sm:w-64 sm:h-16 md:w-80 md:h-20 cursor-pointer flex items-center border border-laranja bg-laranja group hover:bg-laranja active:bg-laranja active:border-laranja"
       :class="{ visible: isVisible, invisible: !isVisible }"
     >
       <span
-        class="text-azul font-inter font-semibold text-lg ml-12 transform group-hover:translate-x-0"
-        >Adicionar item achado</span
+        class="text-azul font-inter font-semibold text-xs sm:text-lg ml-4 sm:ml-12 transform group-hover:translate-x-0"
       >
+        <span class="block lg:hidden">Adicionar achado</span>
+        <span class="hidden lg:block">Adicionar item achado</span>
+      </span>
       <span
-        class="absolute right-0 h-20 w-10 rounded-xl bg-laranja flex items-center justify-center transform group-hover:translate-x-0 group-hover:w-full transition-all duration-300"
+        class="absolute right-0 h-12 w-10 sm:h-16 sm:w-10 md:h-20 md:w-10 rounded-xl bg-laranja flex items-center justify-center transform group-hover:translate-x-0 group-hover:w-full transition-all duration-300"
       >
-        <img src="../assets/icons/add-item.svg" alt="" class="mr-10" />
+        <img src="../assets/icons/add-item.svg" alt="" class="mr-4 sm:mr-10 w-6 h-6 sm:w-8 sm:h-8 md:w-10 md:h-10" />
       </span>
     </button>
   </router-link>
@@ -50,5 +52,47 @@ export default {
 .invisible {
   opacity: 0;
   transform: translateX(70px);
+}
+
+@media (max-width: 769px) and (min-width: 400px) {
+  button {
+    width: 16rem !important;
+    height: 4rem !important;
+  }
+  .text-xs, .sm\:text-lg {
+    font-size: 1.125rem !important;
+    line-height: 1.75rem !important;
+    margin-left: 2rem !important;
+  }
+  .h-12, .sm\:h-16 { height: 4rem !important; }
+  .w-10, .sm\:w-10 { width: 2.5rem !important; }
+  .mr-4, .sm\:mr-10 { margin-right: 3rem !important; }
+  .w-6, .sm\:w-8 { width: 2rem !important; }
+  .h-6, .sm\:h-8 { height: 2rem !important; }
+}
+
+@media (max-width: 799px) {
+  .lg\:block { display: none !important; }
+  .lg\:hidden { display: block !important; }
+}
+@media (min-width: 800px) {
+  .lg\:block { display: block !important; }
+  .lg\:hidden { display: none !important; }
+}
+@media (max-width: 359px) {
+  button {
+    width: 10rem !important;
+    height: 2.5rem !important;
+  }
+  .text-xs, .sm\:text-lg {
+    font-size: 0.75rem !important;
+    line-height: 1rem !important;
+    margin-left: 0.5rem !important;
+  }
+  .h-12, .sm\:h-16 { height: 2.5rem !important; }
+  .w-10, .sm\:w-10 { width: 2.5rem !important; }
+  .mr-4, .sm\:mr-10 { margin-right: 0.5rem !important; }
+  .w-6, .sm\:w-8 { width: 1.25rem !important; }
+  .h-6, .sm\:h-8 { height: 1.25rem !important; }
 }
 </style>

--- a/web/src/components/Button-Add-Lost.vue
+++ b/web/src/components/Button-Add-Lost.vue
@@ -7,8 +7,8 @@
       <span
         class="text-azul font-inter font-semibold text-xs sm:text-lg ml-4 sm:ml-12 transform group-hover:translate-x-0"
       >
-        <span class="block lg:hidden">Adicionar perdido</span>
-        <span class="hidden lg:block">Adicionar item perdido</span>
+        <span class="block max-[769px]:block min-[770px]:hidden">Adicionar perdido</span>
+        <span class="hidden min-[770px]:block">Adicionar item perdido</span>
       </span>
       <span
         class="absolute right-0 h-12 w-10 sm:h-16 sm:w-10 md:h-20 md:w-10 rounded-xl bg-laranja flex items-center justify-center transform group-hover:translate-x-0 group-hover:w-full transition-all duration-300"
@@ -79,20 +79,33 @@ export default {
   .lg\:block { display: block !important; }
   .lg\:hidden { display: none !important; }
 }
-@media (max-width: 359px) {
+@media (max-width: 399px) {
   button {
-    width: 10rem !important;
-    height: 2.5rem !important;
+    width: 64px !important;
+    height: 64px !important;
+    font-size: 2.2rem !important;
+    padding: 0 !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
   }
-  .text-xs, .sm\:text-lg {
-    font-size: 0.75rem !important;
-    line-height: 1rem !important;
-    margin-left: 0.5rem !important;
+  .text-azul, .font-inter, .font-semibold, .text-xs, .sm\:text-lg, .ml-4, .sm\:ml-12 {
+    display: none !important;
   }
-  .h-12, .sm\:h-16 { height: 2.5rem !important; }
-  .w-10, .sm\:w-10 { width: 2.5rem !important; }
-  .mr-4, .sm\:mr-10 { margin-right: 0.5rem !important; }
-  .w-6, .sm\:w-8 { width: 1.25rem !important; }
-  .h-6, .sm\:h-8 { height: 1.25rem !important; }
+  .absolute.right-0 {
+    position: static !important;
+    margin: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+  }
+  img {
+    margin: 0 !important;
+    width: 2.2rem !important;
+    height: 2.2rem !important;
+    display: block !important;
+  }
 }
 </style>

--- a/web/src/components/Button-Add-Lost.vue
+++ b/web/src/components/Button-Add-Lost.vue
@@ -1,17 +1,19 @@
 <template>
   <router-link to="/register-lost">
     <button
-      class="fixed right-0 bottom-28 rounded-l-xl w-80 h-20 cursor-pointer flex items-center border border-laranja bg-laranja group hover:bg-laranja active:bg-laranja active:border-laranja"
+      class="fixed right-0 bottom-28 rounded-l-xl custom-360:w-40 custom-360:h-12 w-48 h-14 sm:w-64 sm:h-16 md:w-80 md:h-20 cursor-pointer flex items-center border border-laranja bg-laranja group hover:bg-laranja active:bg-laranja active:border-laranja"
       :class="{ visible: isVisible, invisible: !isVisible }"
     >
       <span
-        class="text-azul font-inter font-semibold text-lg ml-12 transform group-hover:translate-x-0"
-        >Adicionar item perdido</span
+        class="text-azul font-inter font-semibold text-xs sm:text-lg ml-4 sm:ml-12 transform group-hover:translate-x-0"
       >
+        <span class="block lg:hidden">Adicionar perdido</span>
+        <span class="hidden lg:block">Adicionar item perdido</span>
+      </span>
       <span
-        class="absolute right-0 h-20 w-10 rounded-xl bg-laranja flex items-center justify-center transform group-hover:translate-x-0 group-hover:w-full transition-all duration-300"
+        class="absolute right-0 h-12 w-10 sm:h-16 sm:w-10 md:h-20 md:w-10 rounded-xl bg-laranja flex items-center justify-center transform group-hover:translate-x-0 group-hover:w-full transition-all duration-300"
       >
-        <img src="../assets/icons/add-item.svg" alt="" class="mr-10" />
+        <img src="../assets/icons/add-item.svg" alt="" class="mr-4 sm:mr-10 w-6 h-6 sm:w-8 sm:h-8 md:w-10 md:h-10" />
       </span>
     </button>
   </router-link>
@@ -50,5 +52,47 @@ export default {
 .invisible {
   opacity: 0;
   transform: translateX(70px);
+}
+
+@media (max-width: 769px) and (min-width: 400px) {
+  button {
+    width: 16rem !important;
+    height: 4rem !important;
+  }
+  .text-xs, .sm\:text-lg {
+    font-size: 1.125rem !important;
+    line-height: 1.75rem !important;
+    margin-left: 2rem !important;
+  }
+  .h-12, .sm\:h-16 { height: 4rem !important; }
+  .w-10, .sm\:w-10 { width: 2.5rem !important; }
+  .mr-4, .sm\:mr-10 { margin-right: 3rem !important; }
+  .w-6, .sm\:w-8 { width: 2rem !important; }
+  .h-6, .sm\:h-8 { height: 2rem !important; }
+}
+
+@media (max-width: 799px) {
+  .lg\:block { display: none !important; }
+  .lg\:hidden { display: block !important; }
+}
+@media (min-width: 800px) {
+  .lg\:block { display: block !important; }
+  .lg\:hidden { display: none !important; }
+}
+@media (max-width: 359px) {
+  button {
+    width: 10rem !important;
+    height: 2.5rem !important;
+  }
+  .text-xs, .sm\:text-lg {
+    font-size: 0.75rem !important;
+    line-height: 1rem !important;
+    margin-left: 0.5rem !important;
+  }
+  .h-12, .sm\:h-16 { height: 2.5rem !important; }
+  .w-10, .sm\:w-10 { width: 2.5rem !important; }
+  .mr-4, .sm\:mr-10 { margin-right: 0.5rem !important; }
+  .w-6, .sm\:w-8 { width: 1.25rem !important; }
+  .h-6, .sm\:h-8 { height: 1.25rem !important; }
 }
 </style>

--- a/web/src/components/Form-Found.vue
+++ b/web/src/components/Form-Found.vue
@@ -261,7 +261,7 @@
   <Alert
     v-if="formSubmitted"
     type="success"
-    message="Item publicado com sucesso"
+    :message="editMode ? 'Item editado com sucesso' : 'Item publicado com sucesso'"
     @closed="formSubmitted = false"
   />
 </template>

--- a/web/src/components/Form-Found.vue
+++ b/web/src/components/Form-Found.vue
@@ -1177,20 +1177,34 @@ export default {
   mounted() {
     if (this.editMode && this.existingItem) {
       this.item = Object.assign(new Item(), this.existingItem);
-
       this.previews.push(...this.existingItem.image_urls);
+
+      if (this.item.category) {
+        const cat = this.categories.find(c => c.category_id == this.item.category || c.id == this.item.category);
+        if (cat) this.searchCategory = cat.name;
+      }
+      if (this.item.location) {
+        const loc = this.locations.find(l => l.location_id == this.item.location || l.id == this.item.location);
+        if (loc) this.searchLocation = loc.name;
+      }
+      if (this.item.brand) {
+        const brand = this.brands.find(b => b.brand_id == this.item.brand || b.id == this.item.brand);
+        if (brand) this.searchBrand = brand.name;
+      }
+      if (this.item.color) {
+        const color = this.colors.find(c => c.color_id == this.item.color || c.id == this.item.color);
+        if (color) this.searchColor = color.name;
+      }
 
       if (this.item.found_lost_date) {
         try {
           const date = new Date(this.item.found_lost_date);
-
           this.item.foundDate =
             date.getFullYear() +
             "-" +
             String(date.getMonth() + 1).padStart(2, "0") +
             "-" +
             String(date.getDate()).padStart(2, "0");
-
           this.foundTime =
             String(date.getHours()).padStart(2, "0") +
             ":" +

--- a/web/src/components/Form-Lost.vue
+++ b/web/src/components/Form-Lost.vue
@@ -1183,8 +1183,24 @@ export default {
   mounted() {
     if (this.editMode && this.existingItem) {
       this.item = Object.assign(new Item(), this.existingItem);
-
       this.previews.push(...this.existingItem.image_urls);
+
+      if (this.item.category) {
+        const cat = this.categories.find(c => c.category_id == this.item.category || c.id == this.item.category);
+        if (cat) this.searchCategory = cat.name;
+      }
+      if (this.item.location) {
+        const loc = this.locations.find(l => l.location_id == this.item.location || l.id == this.item.location);
+        if (loc) this.searchLocation = loc.name;
+      }
+      if (this.item.brand) {
+        const brand = this.brands.find(b => b.brand_id == this.item.brand || b.id == this.item.brand);
+        if (brand) this.searchBrand = brand.name;
+      }
+      if (this.item.color) {
+        const color = this.colors.find(c => c.color_id == this.item.color || c.id == this.item.color);
+        if (color) this.searchColor = color.name;
+      }
 
       if (this.item.found_lost_date) {
         try {

--- a/web/src/components/Form-Lost.vue
+++ b/web/src/components/Form-Lost.vue
@@ -264,7 +264,7 @@
   <Alert
     v-if="formSubmitted"
     type="success"
-    message="Item publicado com sucesso"
+    :message="editMode ? 'Item editado com sucesso' : 'Item publicado com sucesso'"
     @closed="formSubmitted = false"
   />
 </template>

--- a/web/src/components/Item-Card.vue
+++ b/web/src/components/Item-Card.vue
@@ -14,6 +14,17 @@
     >
       <img src="../assets/icons/trash.svg" alt="Excluir" />
     </button>
+    
+    <button
+      v-if="isMyItem"
+      class="absolute p-1 bottom-2 border-2 border-azul right-12 w-7 h-7 bg-white flex items-center justify-center text-xs rounded-full cursor-pointer"
+      @click.stop="emit('edit', id)"
+      title="Editar"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-azul">
+        <path d="M11.5 4.5L14 2L12 0L9.5 2.5M11.5 4.5L4.5 11.5L2 14L0 12L2.5 9.5M11.5 4.5L9.5 2.5M2.5 9.5L9.5 2.5" />
+      </svg>
+    </button>
 
     <Teleport to="body">
       <div
@@ -49,11 +60,11 @@
     <div class="h-[2px] w-1/4 bg-laranja mt-4"></div>
 
     <!--textos-->
-    <div class="flex flex-col">
+    <div class="flex flex-col" :class="{'pr-14': isMyItem}">
       <div class="text-azul font-bold font-inter mt-1 truncate">{{ name }}</div>
-      <div class="flex items-start justify-start">
-        <img src="../assets/icons/locale.svg" alt="" class="w-5 h-5 mr-1" />
-        <span class="text-azul font-inter text-md font-medium">{{ location }}</span>
+      <div class="flex items-start justify-start overflow-hidden">
+        <img src="../assets/icons/locale.svg" alt="" class="w-5 h-5 mr-1 flex-shrink-0" />
+        <span class="text-azul font-inter text-md font-medium truncate">{{ location }}</span>
       </div>
     </div>
 
@@ -87,7 +98,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(["delete"]);
+const emit = defineEmits(["delete", "edit"]);
 const router = useRouter();
 const showConfirmModal = ref(false);
 const selectedItemId = ref(null);

--- a/web/src/views/Found.vue
+++ b/web/src/views/Found.vue
@@ -28,8 +28,8 @@
       />
     </div>
 
-    <div v-if="foundItems.length" class="flex w-full justify-start sm:justify-center pb-24">
-      <div class="ml-24 transform -translate-x-1/2 flex gap-4 z-0">
+    <div v-if="foundItems.length" class="flex w-full justify-center pb-24">
+      <div class="flex gap-4 z-0 items-center">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
@@ -45,7 +45,9 @@
             d="m11.25 9-3 3m0 0 3 3m-3-3h7.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
           />
         </svg>
-
+        <span class="font-medium text-base text-azul select-none min-w-[30px] text-center">
+          {{ currentPage }} / {{ totalPages }}
+        </span>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"

--- a/web/src/views/Found.vue
+++ b/web/src/views/Found.vue
@@ -28,8 +28,8 @@
       />
     </div>
 
-    <div v-if="foundItems.length" class="flex w-full justify-start sm:justify-center">
-      <div class="bottom-32 ml-24 transform -translate-x-1/2 flex gap-4 z-10">
+    <div v-if="foundItems.length" class="flex w-full justify-start sm:justify-center pb-24">
+      <div class="ml-24 transform -translate-x-1/2 flex gap-4 z-0">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"

--- a/web/src/views/Found.vue
+++ b/web/src/views/Found.vue
@@ -36,7 +36,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer"
+          class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer hover:scale-125"
           @click="goToPreviousPage"
         >
           <path
@@ -54,7 +54,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer"
+          class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer hover:scale-125"
           @click="goToNextPage"
         >
           <path

--- a/web/src/views/ListItem.vue
+++ b/web/src/views/ListItem.vue
@@ -162,11 +162,41 @@
     <button
       v-else-if="currentUser?.id === item.user_id"
       class="bg-red-500 text-white w-full md:w-[70%] lg:w-[40%] font-medium py-4 rounded-full hover:scale-110 transition-transform duration-300 text-center text-lg lg:text-xl"
-      @click="confirmDelete(item.id)"
+      @click="openDeleteModal"
     >
       Excluir meu item
     </button>
   </div>
+
+  <Teleport to="body">
+    <div
+      v-if="showDeleteModal"
+      class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+    >
+      <div
+        class="bg-azul p-6 rounded-lg shadow-lg w-full max-w-sm sm:max-w-md lg:max-w-lg text-center relative"
+        @click.stop
+      >
+        <p class="text-white font-inter text-lg">
+          Você realmente deseja excluir este item do AcheiUnB?
+        </p>
+        <div class="flex flex-col sm:flex-row justify-center mt-4 gap-4">
+          <button
+            class="bg-red-500 text-white font-inter px-4 py-2 rounded-md hover:bg-red-600 transition w-full sm:w-auto"
+            @click="handleDeleteConfirmed"
+          >
+            Excluir
+          </button>
+          <button
+            class="bg-white font-inter px-4 py-2 rounded-md hover:bg-gray-200 transition w-full sm:w-auto"
+            @click="closeDeleteModal"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
 
   <div class="fixed bottom-0 w-full">
     <MainMenu :activeIcon="itemStatus === 'found' ? 'found' : 'lost'" />
@@ -435,6 +465,31 @@ const submitReport = async () => {
     submitError.value = true;
   } finally {
     isReportSubmitting.value = false;
+  }
+};
+
+const showDeleteModal = ref(false);
+
+const openDeleteModal = () => {
+  showDeleteModal.value = true;
+  document.body.style.overflow = "hidden";
+};
+
+const closeDeleteModal = () => {
+  showDeleteModal.value = false;
+  document.body.style.overflow = "";
+};
+
+const handleDeleteConfirmed = async () => {
+  try {
+    await deleteItem(item.value.id);
+    closeDeleteModal();
+    router.push(`/${itemStatus.value}`);
+  } catch (error) {
+    closeDeleteModal();
+    console.error("Erro ao excluir item:", error);
+    alertMessage.value = "Erro ao excluir item.";
+    submitError.value = true;
   }
 };
 

--- a/web/src/views/Lost.vue
+++ b/web/src/views/Lost.vue
@@ -103,9 +103,10 @@ const fetchItems = async (page = 1) => {
       location_name: activeLocation,
     });
 
-    if (response && response.results && response.count !== undefined) {
+    if (response && response.count !== undefined) {
       lostItems.value = response.results;
       totalPages.value = Math.ceil(response.count / 27);
+      currentPage.value = page; // Atualiza currentPage somente após resposta bem-sucedida
     } else {
       console.error("Resposta da API inválida:", response);
     }
@@ -117,16 +118,14 @@ const fetchItems = async (page = 1) => {
 };
 
 const goToPreviousPage = () => {
-  if (currentPage.value > 1) {
-    currentPage.value -= 1;
-    fetchItems(currentPage.value);
+  if (currentPage.value > 1 && !loading.value) {
+    fetchItems(currentPage.value - 1);
   }
 };
 
 const goToNextPage = () => {
-  if (currentPage.value < totalPages.value) {
-    currentPage.value += 1;
-    fetchItems(currentPage.value);
+  if (currentPage.value < totalPages.value && !loading.value) {
+    fetchItems(currentPage.value + 1);
   }
 };
 

--- a/web/src/views/Lost.vue
+++ b/web/src/views/Lost.vue
@@ -28,8 +28,8 @@
       />
     </div>
 
-    <div v-if="lostItems.length" class="flex w-full justify-start sm:justify-center pb-24">
-      <div class="ml-24 transform -translate-x-1/2 flex gap-4 z-0">
+    <div v-if="lostItems.length" class="flex w-full justify-center pb-24">
+      <div class="flex gap-4 z-0 items-center">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
@@ -45,7 +45,9 @@
             d="m11.25 9-3 3m0 0 3 3m-3-3h7.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
           />
         </svg>
-
+        <span class="font-medium text-base text-azul select-none min-w-[30px] text-center">
+          {{ currentPage }} / {{ totalPages }}
+        </span>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"

--- a/web/src/views/Lost.vue
+++ b/web/src/views/Lost.vue
@@ -28,8 +28,8 @@
       />
     </div>
 
-    <div v-if="lostItems.length" class="flex w-full justify-start sm:justify-center">
-      <div class="ml-24 transform -translate-x-1/2 flex gap-4 z-10">
+    <div v-if="lostItems.length" class="flex w-full justify-start sm:justify-center pb-24">
+      <div class="ml-24 transform -translate-x-1/2 flex gap-4 z-0">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"

--- a/web/src/views/Lost.vue
+++ b/web/src/views/Lost.vue
@@ -36,7 +36,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer"
+          class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer hover:scale-125"
           @click="goToPreviousPage"
         >
           <path
@@ -54,7 +54,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer"
+          class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer hover:scale-125"
           @click="goToNextPage"
         >
           <path

--- a/web/src/views/UserItems-Found.vue
+++ b/web/src/views/UserItems-Found.vue
@@ -55,7 +55,7 @@
         viewBox="0 0 24 24"
         stroke-width="1.5"
         stroke="currentColor"
-        class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer"
+        class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer hover:scale-125"
         @click="goToPreviousPage"
       >
         <path
@@ -73,7 +73,7 @@
         viewBox="0 0 24 24"
         stroke-width="1.5"
         stroke="currentColor"
-        class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer"
+        class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer hover:scale-125"
         @click="goToNextPage"
       >
         <path

--- a/web/src/views/UserItems-Found.vue
+++ b/web/src/views/UserItems-Found.vue
@@ -34,7 +34,7 @@
     class="grid grid-cols-[repeat(auto-fit,_minmax(180px,_1fr))] sm:grid-cols-[repeat(auto-fit,_minmax(200px,_1fr))] justify-items-center align-items-center lg:px-3 gap-y-3 pb-24"
   >
     <ItemCard
-      v-for="item in myItemsFound"
+      v-for="item in paginatedItems"
       :key="item.id"
       :id="item.id"
       :name="item.name"
@@ -46,6 +46,44 @@
     />
   </div>
 
+  <div v-if="myItemsFound.length" class="flex w-full justify-center pb-24">
+    <div class="flex gap-4 z-0 items-center">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer"
+        @click="goToPreviousPage"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="m11.25 9-3 3m0 0 3 3m-3-3h7.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+        />
+      </svg>
+      <span class="font-medium text-base text-azul select-none min-w-[30px] text-center">
+        {{ currentPage }} / {{ totalPages }}
+      </span>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer"
+        @click="goToNextPage"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="m12.75 15 3-3m0 0-3-3m3 3h-7.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+        />
+      </svg>
+    </div>
+  </div>
+
   <ButtonAdd />
   <div class="fixed bottom-0 w-full">
     <MainMenu activeIcon="search" />
@@ -55,7 +93,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from "vue";
+import { ref, onMounted, computed } from "vue";
 import { fetchMyItemsFound, deleteItem } from "@/services/apiItems";
 import { formatTime } from "@/utils/dateUtils";
 import MainMenu from "../components/Main-Menu.vue";
@@ -70,6 +108,10 @@ const submitError = ref(false);
 const formSubmitted = ref(false);
 const alertMessage = ref("");
 const loading = ref(true);
+const currentPage = ref(1);
+const itemsPerPage = 27;
+const totalPages = computed(() => Math.max(1, Math.ceil(myItemsFound.value.length / itemsPerPage)));
+const paginatedItems = computed(() => myItemsFound.value.slice((currentPage.value-1)*itemsPerPage, currentPage.value*itemsPerPage));
 
 const fetchItems = async () => {
   try {
@@ -104,6 +146,13 @@ const handleDelete = async (itemId) => {
     alertMessage.value = "Erro ao deletar o item.";
     submitError.value = true;
   }
+};
+
+const goToPreviousPage = () => {
+  if (currentPage.value > 1) currentPage.value--;
+};
+const goToNextPage = () => {
+  if (currentPage.value < totalPages.value) currentPage.value++;
 };
 
 onMounted(() => fetchItems());

--- a/web/src/views/UserItems-Found.vue
+++ b/web/src/views/UserItems-Found.vue
@@ -43,6 +43,7 @@
       :image="item.image_urls[0] || NotAvailableImage"
       :isMyItem="true"
       @delete="confirmDelete"
+      @edit="handleEdit"
     />
   </div>
 
@@ -94,6 +95,7 @@
 
 <script setup>
 import { ref, onMounted, computed } from "vue";
+import { useRouter } from "vue-router";
 import { fetchMyItemsFound, deleteItem } from "@/services/apiItems";
 import { formatTime } from "@/utils/dateUtils";
 import MainMenu from "../components/Main-Menu.vue";
@@ -102,6 +104,8 @@ import ItemCard from "@/components/Item-Card.vue";
 import Logo from "@/components/Logo.vue";
 import NotAvailableImage from "@/assets/images/not-available.png";
 import EmptyState from "@/components/Empty-State-User.vue";
+
+const router = useRouter();
 
 const myItemsFound = ref([]);
 const submitError = ref(false);
@@ -153,6 +157,10 @@ const goToPreviousPage = () => {
 };
 const goToNextPage = () => {
   if (currentPage.value < totalPages.value) currentPage.value++;
+};
+
+const handleEdit = (itemId) => {
+  router.push(`/edit-item/${itemId}`);
 };
 
 onMounted(() => fetchItems());

--- a/web/src/views/UserItems-Lost.vue
+++ b/web/src/views/UserItems-Lost.vue
@@ -34,7 +34,7 @@
     class="grid grid-cols-[repeat(auto-fit,_minmax(180px,_1fr))] sm:grid-cols-[repeat(auto-fit,_minmax(200px,_1fr))] justify-items-center align-items-center lg:px-3 gap-y-3 pb-24"
   >
     <ItemCard
-      v-for="item in myItemsLost"
+      v-for="item in paginatedItems"
       :key="item.id"
       :id="item.id"
       :name="item.name"
@@ -44,6 +44,44 @@
       :isMyItem="true"
       @delete="confirmDelete"
     />
+  </div>
+
+  <div v-if="myItemsLost.length" class="flex w-full justify-center pb-24">
+    <div class="flex gap-4 z-0 items-center">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer"
+        @click="goToPreviousPage"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="m11.25 9-3 3m0 0 3 3m-3-3h7.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+        />
+      </svg>
+      <span class="font-medium text-base text-azul select-none min-w-[30px] text-center">
+        {{ currentPage }} / {{ totalPages }}
+      </span>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer"
+        @click="goToNextPage"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="m12.75 15 3-3m0 0-3-3m3 3h-7.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+        />
+      </svg>
+    </div>
   </div>
 
   <ButtonAdd />
@@ -56,7 +94,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from "vue";
+import { ref, onMounted, computed } from "vue";
 import { fetchMyItemsLost, deleteItem } from "@/services/apiItems";
 import { formatTime } from "@/utils/dateUtils";
 import MainMenu from "../components/Main-Menu.vue";
@@ -72,6 +110,10 @@ const submitError = ref(false);
 const formSubmitted = ref(false);
 const alertMessage = ref("");
 const loading = ref(true);
+const currentPage = ref(1);
+const itemsPerPage = 27;
+const totalPages = computed(() => Math.max(1, Math.ceil(myItemsLost.value.length / itemsPerPage)));
+const paginatedItems = computed(() => myItemsLost.value.slice((currentPage.value-1)*itemsPerPage, currentPage.value*itemsPerPage));
 
 const fetchItems = async () => {
   try {
@@ -106,6 +148,13 @@ const handleDelete = async (itemId) => {
     alertMessage.value = "Erro ao deletar o item.";
     submitError.value = true;
   }
+};
+
+const goToPreviousPage = () => {
+  if (currentPage.value > 1) currentPage.value--;
+};
+const goToNextPage = () => {
+  if (currentPage.value < totalPages.value) currentPage.value++;
 };
 
 onMounted(() => fetchItems());

--- a/web/src/views/UserItems-Lost.vue
+++ b/web/src/views/UserItems-Lost.vue
@@ -43,6 +43,7 @@
       :image="item.image_urls[0] || NotAvailableImage"
       :isMyItem="true"
       @delete="confirmDelete"
+      @edit="handleEdit"
     />
   </div>
 
@@ -95,6 +96,7 @@
 
 <script setup>
 import { ref, onMounted, computed } from "vue";
+import { useRouter } from "vue-router";
 import { fetchMyItemsLost, deleteItem } from "@/services/apiItems";
 import { formatTime } from "@/utils/dateUtils";
 import MainMenu from "../components/Main-Menu.vue";
@@ -104,6 +106,8 @@ import Alert from "@/components/Alert.vue";
 import Logo from "@/components/Logo.vue";
 import NotAvailableImage from "@/assets/images/not-available.png";
 import EmptyState from "@/components/Empty-State-User.vue";
+
+const router = useRouter();
 
 const myItemsLost = ref([]);
 const submitError = ref(false);
@@ -155,6 +159,10 @@ const goToPreviousPage = () => {
 };
 const goToNextPage = () => {
   if (currentPage.value < totalPages.value) currentPage.value++;
+};
+
+const handleEdit = (itemId) => {
+  router.push(`/edit-item/${itemId}`);
 };
 
 onMounted(() => fetchItems());

--- a/web/src/views/UserItems-Lost.vue
+++ b/web/src/views/UserItems-Lost.vue
@@ -55,7 +55,7 @@
         viewBox="0 0 24 24"
         stroke-width="1.5"
         stroke="currentColor"
-        class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer"
+        class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer hover:scale-125"
         @click="goToPreviousPage"
       >
         <path
@@ -73,7 +73,7 @@
         viewBox="0 0 24 24"
         stroke-width="1.5"
         stroke="currentColor"
-        class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer"
+        class="size-10 text-azul hover:text-laranja transition duration-200 cursor-pointer hover:scale-125"
         @click="goToNextPage"
       >
         <path


### PR DESCRIPTION
# Descrição do Pull Request

## O que foi feito?

- **Correção de paginação:** Ajustada a lógica de paginação nas páginas `Lost`, `Found`, `Meus Itens Perdidos` e `Meus Itens Achados` para garantir que as setas de navegação e o indicador de página funcionem corretamente, sincronizando com a API do Django. Adicionado efeito de escala (hover) nos botões de paginação para melhorar a experiência visual.

- **Padronização de botões flutuantes:** O botão "Adicionar perdido" foi ajustado para ter o mesmo comportamento visual e responsivo do botão "Adicionar achado". Garantido que ambos os botões sejam consistentes em todas as telas.

- **Adição de botão de edição:** Implementado um botão de edição no componente `ItemCard` para itens ativos, com estilo semelhante ao botão de exclusão.

- **Correção de responsividade:** Ajustado o comportamento dos botões flutuantes para telas menores que 400px, garantindo que o símbolo "+" não fique quebrado.

- **Melhoria na navegação:** Adicionado o indicador de página atual e total de páginas nas páginas de "Meus Itens Ativos".

- **Padronização de modais de exclusão:** Garantido que todos os modais de exclusão (itens e usuários) sigam o mesmo padrão visual e funcional.

## Checklist

- [x] Meu código segue as diretrizes do projeto.
- [x] Adicionei testes para cobrir as mudanças.
- [x] Atualizei a documentação, se necessário.
