### PR TITLE
fix(Filtros): Corrige erro ao selecionar um filtro pela primeira vez …

### DIFF
--- a/web/src/components/SearchBar.vue
+++ b/web/src/components/SearchBar.vue
@@ -69,7 +69,7 @@
 
     <div
       v-if="showFilters"
-      class="absolute left-0 bg-gray-200 shadow-lg rounded-xl p-4 z-30"
+      class="absolute left-0 bg-gray-200 shadow-lg rounded-xl p-4 z-30 overflow-y-auto max-h-[670px]"
       :class="{
         'w-fit mr-8': isActive && !isMediumOrLarger,
         'w-full': isMediumOrLarger,
@@ -79,12 +79,13 @@
       <div class="flex gap-2 flex-wrap mt-4">
         <span class="w-full text-azul text-2xl font-bold">Categoria </span>
         <button
+          type="button"
           v-for="(filter, index) in categories"
           :key="index"
-          @click="(toggleFilter('category', index), setActiveCategory(filter.label))"
+          @click="setActiveCategory(filter.label)"
           :class="[
             'px-4 py-2 rounded-full border text-sm',
-            filter.active
+            filtersState.activeCategory === filter.label
               ? 'bg-laranja text-azul border-black'
               : 'bg-gray-200 text-azul border-black',
           ]"
@@ -96,12 +97,13 @@
       <div class="flex gap-2 flex-wrap mt-4">
         <span class="w-full text-azul text-2xl font-bold">Local </span>
         <button
+          type="button"
           v-for="(filter, index) in locations"
           :key="index"
-          @click="(toggleFilter('location', index), setActiveLocation(filter.label))"
+          @click=" setActiveLocation(filter.label)"
           :class="[
             'px-4 py-2 rounded-full border text-sm',
-            filter.active
+            filtersState.activeLocation === filter.label
               ? 'bg-laranja text-azul border-black'
               : 'bg-gray-200 text-azul border-black',
           ]"


### PR DESCRIPTION
# Descrição do Pull Request
<!-- Descreva de forma clara e concisa o que foi feito neste PR. -->

Foram corrigidos bugs relacionados a filtragem de itens por categoria e localização, além de uma correção na parte visual do filtro para telas mobiles.

## O que foi feito?

- Seleção de categoria não pode ser desfeita sem atualizar a página:
  - Havia um problema na lógica ao clicar no botão, onde chamava um método desnecessariamente que causava o problema.

- Corrigir erro do Filtro (ao selecionar um filtro pela primeira vez, ele recarrega a página, e só depois, clicando novamente, que a filtragem acontece):
  - Os botões de categorias e de locais, estão dentro de um form, porém o 'type' deles não estava sendo especificado, fazendo com que o formulário fosse enviado ao clicar neles pela primeira vez.
  - Foi adicionado o 'type="button"' nos botões, que impede o envio automático do formulário.

- Corrigir o Filtro em telas mobile (ocupa a tela inteira e não é possível scrollar):
   - A div onde está os filtros não possuia uma altura fixa e não era possível rolar ela
   - Foi adicionado uma altura fixa e o atributo "overflow-y-auto" fixando a altura em telas pequenas e permitindo o rolamento do filtro.

## Checklist

- [x] Meu código segue as diretrizes do projeto.
- [ ] Adicionei testes para cobrir as mudanças.
- [ ] Atualizei a documentação, se necessário.

Closes #280 