### PR TITLE
 Fix(Bug): Adicionada validação para impedir datas inválidas em itens (Issue #303)

### DIFF
--- a/API/users/models.py
+++ b/API/users/models.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
 from django.db import models
+from users.utils.validators import validate_date_not_too_old
 
 
 class UserProfile(models.Model):
@@ -55,7 +56,11 @@ class Item(models.Model):
     color = models.ForeignKey(Color, on_delete=models.SET_NULL, null=True, blank=True)
     brand = models.ForeignKey(Brand, on_delete=models.SET_NULL, null=True, blank=True)
     status = models.CharField(max_length=10, choices=STATUS_CHOICES, default="lost")
-    found_lost_date = models.DateTimeField(null=True, blank=True)
+    found_lost_date = models.DateTimeField(
+        null=True, 
+        blank=True, 
+        validators=[validate_date_not_too_old]
+        )
     created_at = models.DateTimeField(auto_now_add=True)
 
     barcode = models.CharField(max_length=10, editable=False, blank=True)

--- a/API/users/tests/test_item_date_api_create.py
+++ b/API/users/tests/test_item_date_api_create.py
@@ -1,0 +1,33 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+from django.contrib.auth.models import User
+
+
+@pytest.mark.django_db
+def test_api_create_rejects_too_old_date():
+
+    client = APIClient()
+
+    user = User.objects.create_user(
+        username="api_tester",
+        email="api@test.com",
+        password="123"
+    )
+    client.force_authenticate(user=user)
+
+    data = {
+        "name": "Item API Antigo",
+        "status": "lost",
+        "found_lost_date": "1830-04-19T00:00:00Z",
+        "category": 1,
+        "location": 1
+    }
+
+    url = reverse("item-list")
+
+    response = client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "found_lost_date" in response.json()

--- a/API/users/tests/test_item_date_api_patch.py
+++ b/API/users/tests/test_item_date_api_patch.py
@@ -1,0 +1,35 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+from users.models import User
+
+@pytest.mark.django_db
+def test_api_patch_rejects_too_old_date():
+    
+    client = APIClient()
+    
+    user = User.objects.create_user(username="patch_tester", email="patch@test.com", password="123")
+    client.force_authenticate(user=user)
+
+    url_create = reverse("item-list")
+    data_valid = {
+        "name": "Item Valido",
+        "status": "lost",
+        "found_lost_date": "2024-01-01T12:00:00Z",
+        "category_id": 1, 
+        "location_id": 1
+    }
+    response_create = client.post(url_create, data_valid, format='json')
+    assert response_create.status_code == status.HTTP_201_CREATED
+    item_id = response_create.json()['id']
+
+    url_patch = reverse("item-detail", args=[item_id])
+    data_invalid = {
+        "found_lost_date": "1830-04-19T00:00:00Z"
+    }
+    
+    response_patch = client.patch(url_patch, data_invalid, format='json')
+
+    assert response_patch.status_code == status.HTTP_400_BAD_REQUEST
+    assert "found_lost_date" in response_patch.json()

--- a/API/users/tests/test_item_date_serializer.py
+++ b/API/users/tests/test_item_date_serializer.py
@@ -1,0 +1,24 @@
+import pytest
+from users.serializers import ItemSerializer
+
+@pytest.mark.django_db
+def test_serializer_rejects_old_date():
+    data = {
+        "name": "Carteira",
+        "status": "lost",
+        "found_lost_date": "1830-04-19T00:00:00Z",
+    }
+    s = ItemSerializer(data=data)
+    assert not s.is_valid()
+    assert "found_lost_date" in s.errors
+
+
+@pytest.mark.django_db
+def test_serializer_accepts_valid_date():
+    data = {
+        "name": "Chave",
+        "status": "lost",
+        "found_lost_date": "2023-01-01T00:00:00Z",
+    }
+    s = ItemSerializer(data=data)
+    assert s.is_valid(), s.errors

--- a/API/users/tests/test_item_date_validator.py
+++ b/API/users/tests/test_item_date_validator.py
@@ -1,0 +1,27 @@
+from datetime import date, datetime
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from users.utils.validators import (
+    MIN_ACCEPTABLE_DATE,
+    validate_date_not_too_old,
+)
+
+
+def test_rejects_too_old_date():
+    old = date(1830, 4, 19)
+    with pytest.raises(ValidationError):
+        validate_date_not_too_old(old)
+
+
+def test_accepts_limit_date():
+    limit = MIN_ACCEPTABLE_DATE
+    # não deve falhar
+    validate_date_not_too_old(limit)
+
+
+def test_accepts_datetime_object():
+    dt = datetime(1900, 1, 1, 12, 0, 0)
+    validate_date_not_too_old(dt)
+

--- a/API/users/utils/validators.py
+++ b/API/users/utils/validators.py
@@ -1,0 +1,20 @@
+from datetime import date
+from django.core.exceptions import ValidationError
+
+MIN_ACCEPTABLE_DATE = date(1900, 1, 1)
+
+def validate_date_not_too_old(value):
+    if value is None:
+        return value
+
+    try:
+        value_date = value.date() if hasattr(value, "date") else value
+    except Exception:
+        return value
+
+    if value_date < MIN_ACCEPTABLE_DATE:
+        raise ValidationError(
+            f"Data muito antiga. A data mínima permitida é {MIN_ACCEPTABLE_DATE.isoformat()}."
+        )
+
+    return value


### PR DESCRIPTION
## O que foi feito?

- Corrigido o problema que permitia a criação/edição de itens com datas anteriores a 1900 (issue: #303).
- Criado validador centralizado em `users/utils/validators.py` para manter a lógica consistente e reutilizável.
- Integrada a validação ao modelo `Item` e ao `ItemSerializer`.
- Garantido que os endpoints da API retornem **HTTP 400 Bad Request** quando uma data inválida é enviada.
- Adicionados testes cobrindo:
  - função validadora isolada (teste unitário);
  - validação no serializer;
  - criação via API (POST `/items/`);
  - edição via API (PATCH `/items/<id>/`).

## Checklist

- [x] Meu código segue as diretrizes do projeto.
- [x] Adicionei testes para cobrir as mudanças.
- [x] Não quebrei nenhum comportamento pré-existente da API.
- [x] Evitei duplicar lógica (regra de validação extraída para módulo utilitário).
- [ ] Atualizei a documentação, se necessário.