### PR TITLE
refactor: atualização no match de itens utilizando merge sort

### DIFF
--- a/API/users/match.py
+++ b/API/users/match.py
@@ -1,3 +1,4 @@
+from .match_ranking import get_ranked_items
 from .models import Item
 from .tasks import send_match_notification
 
@@ -50,10 +51,12 @@ def find_and_notify_matches(target_item: Item, max_distance=2):
             target_item, opposite_status="found", max_distance=max_distance
         )
         if matches:
-            target_item.matches.add(*matches)
+            ranked_matches = get_ranked_items(target_item, matches)
+
+            target_item.matches.add(*ranked_matches)
             target_item.save()
 
-            match_data = generate_match_data(matches)
+            match_data = generate_match_data(ranked_matches)
             send_match_notification.delay(
                 to_email=target_item.user.email,
                 item_name=target_item.name,
@@ -68,8 +71,10 @@ def find_and_notify_matches(target_item: Item, max_distance=2):
             lost_item.matches.add(target_item)
             lost_item.save()
 
-            updated_matches = lost_item.matches.all()
-            match_data = generate_match_data(updated_matches)
+            updated_matches = list(lost_item.matches.all())
+            ranked_matches = get_ranked_items(lost_item, updated_matches)
+
+            match_data = generate_match_data(ranked_matches)
             send_match_notification.delay(
                 to_email=lost_item.user.email,
                 item_name=lost_item.name,

--- a/API/users/match_ranking.py
+++ b/API/users/match_ranking.py
@@ -1,0 +1,208 @@
+import re
+import unicodedata
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+
+from .merge_sort import merge_sort
+
+
+@dataclass(frozen=True)
+class RankedMatch:
+    """Representa um candidato de match junto com sua pontuação."""
+    item: Any
+    score: float
+
+
+def normalize_text(text: str | None) -> str:
+    """Normaliza texto para comparação, removendo acentos e pontuação."""
+    if not text:
+        return ""
+
+    normalized = text.lower()
+    normalized = unicodedata.normalize("NFD", normalized)
+    normalized = "".join(
+        character for character in normalized if unicodedata.category(character) != "Mn"
+    )
+    normalized = re.sub(r"[^a-z0-9\s]", " ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+
+    return normalized
+
+
+def tokenize(text: str | None) -> set[str]:
+    """Transforma um texto em um conjunto de palavras normalizadas."""
+    normalized = normalize_text(text)
+
+    if not normalized:
+        return set()
+
+    return set(normalized.split())
+
+
+def text_similarity(first_text: str | None, second_text: str | None) -> float:
+    """
+    Calcula similaridade textual usando índice de Jaccard.
+
+    O resultado varia entre 0 e 1:
+    - 0: nenhuma palavra em comum;
+    - 1: os conjuntos de palavras são iguais.
+    """
+    first_tokens = tokenize(first_text)
+    second_tokens = tokenize(second_text)
+
+    if not first_tokens or not second_tokens:
+        return 0.0
+
+    intersection = first_tokens.intersection(second_tokens)
+    union = first_tokens.union(second_tokens)
+
+    return len(intersection) / len(union)
+
+
+def date_similarity(first_date: Any, second_date: Any, max_days: int = 30) -> float:
+    """
+    Calcula proximidade entre as datas.
+
+    Quanto menor a diferença entre as datas, maior a pontuação,
+    sendo que diferenças iguais ou maiores que max_days recebem 0.
+    """
+    parsed_first_date = _parse_date(first_date)
+    parsed_second_date = _parse_date(second_date)
+
+    if not parsed_first_date or not parsed_second_date:
+        return 0.0
+
+    days_difference = abs((parsed_first_date - parsed_second_date).days)
+
+    if days_difference >= max_days:
+        return 0.0
+
+    return 1 - (days_difference / max_days)
+
+
+def calculate_similarity_score(target_item: Any, candidate_item: Any) -> float:
+    """
+    Calcula score de similaridade entre item alvo e candidato.
+
+    A pontuação final vai de 0 a 100. Os pesos escolhidos priorizam o nome do
+    item, a descrição, a cor e a marca, e por fim, a proximidade entre datas.
+    """
+    name_score = text_similarity(
+        _get_attribute(target_item, "name"),
+        _get_attribute(candidate_item, "name"),
+    )
+    description_score = text_similarity(
+        _get_attribute(target_item, "description"),
+        _get_attribute(candidate_item, "description"),
+    )
+    color_score = categorical_similarity(
+        target_item,
+        candidate_item,
+        "color"
+    )
+    brand_score = categorical_similarity(
+        target_item,
+        candidate_item,
+        "brand"
+    )
+    date_score = date_similarity(
+        _get_attribute(target_item, "found_lost_date"),
+        _get_attribute(candidate_item, "found_lost_date"),
+    )
+
+    final_score = (
+        (name_score * 0.40)
+        + (description_score * 0.25)
+        + (color_score * 0.15)
+        + (brand_score * 0.15)
+        + (date_score * 0.05)
+    )
+
+    return round(final_score * 100, 2)
+
+
+def _get_attribute(item: Any, attribute_name: str) -> Any:
+    """Lê atributo de objetos ou dicionários."""
+    if isinstance(item, dict):
+        return item.get(attribute_name)
+
+    return getattr(item, attribute_name, None)
+
+
+def _get_named_attribute(item: Any, attribute_name: str) -> str:
+    """Lê atributos com opções de escolha como cor e marca."""
+    value = _get_attribute(item, attribute_name)
+
+    if value is None:
+        return ""
+
+    if isinstance(value, str):
+        return value
+
+    if hasattr(value, "name"):
+        return str(value.name)
+
+    return str(value)
+
+
+def categorical_similarity(
+    target_item: Any, candidate_item: Any, attribute_name: str
+) -> float:
+    """Compara atributos categóricos como cor e marca, retornando 1 para correspondência exata e 0 caso contrário."""
+    target_value = _get_named_attribute(target_item, attribute_name)
+    candidate_value = _get_named_attribute(candidate_item, attribute_name)
+
+    if not target_value or not candidate_value:
+        return 0.0
+
+    return 1.0 if normalize_text(target_value) == normalize_text(candidate_value) else 0.0
+
+
+def _parse_date(value: Any) -> date | None:
+    """Extrai a data de um datetime e retorna None para valores ausentes."""
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        return value.date()
+
+    return None
+
+
+def rank_match_candidates(
+    target_item: Any,
+    candidates: list[Any],
+    min_score: float = 36,
+) -> list[RankedMatch]:
+    """
+    Calcula o score de cada candidato e ordena usando Merge Sort.
+
+    Args:
+        target_item: item perdido/encontrado usado como referência.
+        candidates: lista de possíveis matches já filtrados por status, categoria e local.
+        min_score: pontuação mínima para manter um candidato como um match.
+
+    Returns:
+        Lista de RankedMatch em ordem decrescente de score.
+    """
+    ranked_matches = []
+
+    for candidate in candidates:
+        score = calculate_similarity_score(target_item, candidate)
+
+        if score >= min_score:
+            ranked_matches.append(RankedMatch(item=candidate, score=score))
+
+    return merge_sort(ranked_matches, key=lambda match: match.score, reverse=True)
+
+
+def get_ranked_items(
+    target_item: Any,
+    candidates: list[Any],
+    min_score: float = 36,
+) -> list[Any]:
+    """Retorna apenas os matches, já ordenados por similaridade."""
+    ranked_matches = rank_match_candidates(target_item, candidates, min_score=min_score)
+
+    return [ranked_match.item for ranked_match in ranked_matches]

--- a/API/users/match_ranking.py
+++ b/API/users/match_ranking.py
@@ -10,6 +10,7 @@ from .merge_sort import merge_sort
 @dataclass(frozen=True)
 class RankedMatch:
     """Representa um candidato de match junto com sua pontuação."""
+
     item: Any
     score: float
 
@@ -96,16 +97,8 @@ def calculate_similarity_score(target_item: Any, candidate_item: Any) -> float:
         _get_attribute(target_item, "description"),
         _get_attribute(candidate_item, "description"),
     )
-    color_score = categorical_similarity(
-        target_item,
-        candidate_item,
-        "color"
-    )
-    brand_score = categorical_similarity(
-        target_item,
-        candidate_item,
-        "brand"
-    )
+    color_score = categorical_similarity(target_item, candidate_item, "color")
+    brand_score = categorical_similarity(target_item, candidate_item, "brand")
     date_score = date_similarity(
         _get_attribute(target_item, "found_lost_date"),
         _get_attribute(candidate_item, "found_lost_date"),
@@ -149,7 +142,10 @@ def _get_named_attribute(item: Any, attribute_name: str) -> str:
 def categorical_similarity(
     target_item: Any, candidate_item: Any, attribute_name: str
 ) -> float:
-    """Compara atributos categóricos como cor e marca, retornando 1 para correspondência exata e 0 caso contrário."""
+    """
+    Compara atributos categóricos como cor e marca, retornando 1 para
+    correspondência exata e 0 caso contrário.
+    """
     target_value = _get_named_attribute(target_item, attribute_name)
     candidate_value = _get_named_attribute(candidate_item, attribute_name)
 

--- a/API/users/merge_sort.py
+++ b/API/users/merge_sort.py
@@ -1,0 +1,76 @@
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def merge_sort(
+    values: Sequence[T],
+    key: Callable[[T], object] = lambda value: value,
+    reverse: bool = False,
+) -> list[T]:
+    """
+    Ordena uma sequência utilizando Merge Sort.
+
+    A implementação é estável: quando dois elementos possuem a mesma chave,
+    o elemento que apareceu primeiro na lista original continua vindo primeiro
+    no resultado.
+
+    Args:
+        values: sequência de scores de similaridade a ser ordenada.
+        key: função que extrai a chave de ordenação de cada valor.
+        reverse: quando True, ordena em ordem decrescente.
+
+    Returns:
+        Nova lista ordenada.
+    """
+    values = list(values)
+
+    if len(values) <= 1:
+        return values
+
+    middle = len(values) // 2
+    left = merge_sort(values[:middle], key=key, reverse=reverse)
+    right = merge_sort(values[middle:], key=key, reverse=reverse)
+
+    return _merge(left, right, key, reverse)
+
+
+def _merge(
+    left: list[T],
+    right: list[T],
+    key: Callable[[T], object],
+    reverse: bool,
+) -> list[T]:
+    """Intercala duas listas que já estão ordenadas."""
+    result: list[T] = []
+    i = 0
+    j = 0
+
+    while i < len(left) and j < len(right):
+        left_key = key(left[i])
+        right_key = key(right[j])
+
+        if _comes_before_or_ties(left_key, right_key, reverse):
+            result.append(left[i])
+            i += 1
+        else:
+            result.append(right[j])
+            j += 1
+
+    result.extend(left[i:])
+    result.extend(right[j:])
+
+    return result
+
+
+def _comes_before_or_ties(left_key: object, right_key: object, reverse: bool) -> bool:
+    """
+    Decide se a chave da esquerda deve vir antes da chave da direita.
+
+    O empate retorna True para preservar estabilidade do Merge Sort.
+    """
+    if reverse:
+        return left_key >= right_key
+
+    return left_key <= right_key

--- a/API/users/tests/test_match_ranking.py
+++ b/API/users/tests/test_match_ranking.py
@@ -1,0 +1,210 @@
+from datetime import datetime
+
+from users.match_ranking import (
+    calculate_similarity_score,
+    categorical_similarity,
+    date_similarity,
+    get_ranked_items,
+    normalize_text,
+    rank_match_candidates,
+    text_similarity,
+)
+
+
+def test_normaliza_texto_removendo_acentos_e_pontuacao():
+    """Remove acentos e pontuação, e converte para minúsculas."""
+    assert normalize_text("Fône Bluetooth, PRÉTO!") == "fone bluetooth preto"
+
+
+def test_similaridade_textual_parcial():
+    """Retorna um valor entre 0 e 1, onde 1 é texto idêntico e 0 é completamente diferente."""
+    score = text_similarity("fone bluetooth preto", "fone preto sem fio")
+
+    assert 0 < score < 1
+
+
+def test_cor_e_marca_iguais():
+    """Retorna 1 para cor e/ou marca iguais."""
+    target = {
+        "color": "Preto",
+        "brand": "JBL",
+    }
+    candidate = {
+        "color": "Preto",
+        "brand": "JBL",
+    }
+
+    assert categorical_similarity(target, candidate, "color") == 1.0
+    assert categorical_similarity(target, candidate, "brand") == 1.0
+
+
+def test_cor_e_marca_diferentes():
+    """Retorna 0 para cor e/ou marca diferentes."""
+    target = {
+        "color": "Preto",
+        "brand": "JBL",
+    }
+    candidate = {
+        "color": "Branco",
+        "brand": "Samsung",
+    }
+
+    assert categorical_similarity(target, candidate, "color") == 0.0
+    assert categorical_similarity(target, candidate, "brand") == 0.0
+
+
+def test_datas_proximas_tem_score_maior():
+    """Compara as datas e retorna maior score para datas mais próximas."""
+    target_date = datetime(2026, 4, 10, 10, 30)
+    close_date = datetime(2026, 4, 11, 14, 0)
+    far_date = datetime(2026, 5, 20, 14, 0)
+
+    close_score = date_similarity(target_date, close_date)
+    far_score = date_similarity(target_date, far_date)
+
+    assert close_score > far_score
+    assert far_score == 0.0
+
+
+def test_candidato_mais_parecido_tem_score_maior():
+    """Demonstra que o candidato mais parecido deve ter score maior que candidato menos parecido."""
+    target = {
+        "name": "Fone bluetooth preto",
+        "description": "Fone sem fio com estojo oval e borrachas pequenas.",
+        "color": "Preto",
+        "brand": "JBL",
+        "found_lost_date": datetime(2026, 4, 10, 10, 0),
+    }
+
+    similar_candidate = {
+        "name": "Fone bluetooth preto",
+        "description": "Fone sem fio com estojo oval e borrachas pequenas.",
+        "color": "Preto",
+        "brand": "JBL",
+        "found_lost_date": datetime(2026, 4, 11, 10, 0),
+    }
+
+    weak_candidate = {
+        "name": "Carregador de notebook",
+        "description": "Carregador com cabo grosso e conector redondo.",
+        "color": "Branco",
+        "brand": "Dell",
+        "found_lost_date": datetime(2026, 4, 11, 10, 0),
+    }
+
+    similar_score = calculate_similarity_score(target, similar_candidate)
+    weak_score = calculate_similarity_score(target, weak_candidate)
+
+    assert similar_score > weak_score
+
+
+def test_ordena_candidatos_por_score_decrescente():
+    """Ordena os candidatos por score decrescente."""
+    target = {
+        "name": "Fone bluetooth preto",
+        "description": "Fone sem fio com estojo oval e borrachas pequenas.",
+        "color": "Preto",
+        "brand": "JBL",
+        "found_lost_date": datetime(2026, 4, 10, 10, 0),
+    }
+
+    candidates = [
+        {
+            "id": 1,
+            "name": "Carregador de notebook",
+            "description": "Carregador com cabo grosso e conector redondo.",
+            "color": "Branco",
+            "brand": "Dell",
+            "found_lost_date": datetime(2026, 4, 10, 10, 0),
+        },
+        {
+            "id": 2,
+            "name": "Fone bluetooth preto",
+            "description": "Fone sem fio com estojo oval e borrachas pequenas.",
+            "color": "Preto",
+            "brand": "JBL",
+            "found_lost_date": datetime(2026, 4, 11, 10, 0),
+        },
+        {
+            "id": 3,
+            "name": "Fone preto",
+            "description": "Fone com estojo oval preto e borrachas pequenas.",
+            "color": "Preto",
+            "brand": "Sony",
+            "found_lost_date": datetime(2026, 4, 12, 10, 0),
+        },
+    ]
+
+    result = rank_match_candidates(target, candidates, min_score=0)
+
+    assert [ranked_match.item["id"] for ranked_match in result] == [2, 3, 1]
+    assert result[0].score >= result[1].score >= result[2].score
+
+
+def test_filtra_candidatos_abaixo_do_score_minimo():
+    """Filtra candidatos com score abaixo do mínimo (36) e ordena os restantes por score decrescente."""
+    target = {
+        "name": "Fone bluetooth preto",
+        "description": "Fone sem fio com estojo oval e borrachas pequenas.",
+        "color": "Preto",
+        "brand": "JBL",
+        "found_lost_date": datetime(2026, 4, 10, 10, 0),
+    }
+
+    candidates = [
+        {
+            "id": 1,
+            "name": "Fone bluetooth preto",
+            "description": "Fone sem fio com estojo oval e borrachas pequenas.",
+            "color": "Preto",
+            "brand": "JBL",
+            "found_lost_date": datetime(2026, 4, 11, 10, 0),
+        },
+        {
+            "id": 2,
+            "name": "Garrafa azul",
+            "description": "Garrafa térmica com tampa rosqueável e alça lateral.",
+            "color": "Azul",
+            "brand": "Stanley",
+            "found_lost_date": datetime(2026, 4, 25, 10, 0),
+        },
+    ]
+
+    result = rank_match_candidates(target, candidates)
+
+    assert [ranked_match.item["id"] for ranked_match in result] == [1]
+    assert all(ranked_match.score >= 36 for ranked_match in result)
+
+
+def test_retorna_apenas_items_ordenados():
+    """Retorna apenas os matches ordenados (mais provável para o menos provável) a serem enviados para o usuário."""
+    target = {
+        "name": "Fone bluetooth preto",
+        "description": "Fone sem fio com estojo oval e borrachas pequenas.",
+        "color": "Preto",
+        "brand": "JBL",
+        "found_lost_date": datetime(2026, 4, 10, 10, 0),
+    }
+
+    candidates = [
+        {
+            "id": 1,
+            "name": "Mouse vermelho",
+            "description": "Mouse com botão lateral e roda de rolagem.",
+            "color": "Vermelho",
+            "brand": "Logitech",
+            "found_lost_date": datetime(2026, 4, 12, 10, 0),
+        },
+        {
+            "id": 2,
+            "name": "Fone bluetooth preto",
+            "description": "Fone sem fio com estojo oval e borrachas pequenas.",
+            "color": "Preto",
+            "brand": "JBL",
+            "found_lost_date": datetime(2026, 4, 11, 10, 0),
+        },
+    ]
+
+    result = get_ranked_items(target, candidates)
+
+    assert [item["id"] for item in result] == [2]

--- a/API/users/tests/test_match_ranking.py
+++ b/API/users/tests/test_match_ranking.py
@@ -67,7 +67,10 @@ def test_datas_proximas_tem_score_maior():
 
 
 def test_candidato_mais_parecido_tem_score_maior():
-    """Demonstra que o candidato mais parecido deve ter score maior que candidato menos parecido."""
+    """
+    Demonstra que o candidato mais parecido deve ter score maior que
+    candidato menos parecido.
+    """
     target = {
         "name": "Fone bluetooth preto",
         "description": "Fone sem fio com estojo oval e borrachas pequenas.",
@@ -142,7 +145,10 @@ def test_ordena_candidatos_por_score_decrescente():
 
 
 def test_filtra_candidatos_abaixo_do_score_minimo():
-    """Filtra candidatos com score abaixo do mínimo (36) e ordena os restantes por score decrescente."""
+    """
+    Filtra candidatos com score abaixo do mínimo (36) e ordena os
+    restantes por score decrescente.
+    """
     target = {
         "name": "Fone bluetooth preto",
         "description": "Fone sem fio com estojo oval e borrachas pequenas.",
@@ -177,7 +183,10 @@ def test_filtra_candidatos_abaixo_do_score_minimo():
 
 
 def test_retorna_apenas_items_ordenados():
-    """Retorna apenas os matches ordenados (mais provável para o menos provável) a serem enviados para o usuário."""
+    """
+    Retorna apenas os matches ordenados (mais provável para o menos
+    provável) a serem enviados para o usuário.
+    """
     target = {
         "name": "Fone bluetooth preto",
         "description": "Fone sem fio com estojo oval e borrachas pequenas.",

--- a/API/users/tests/test_merge_sort.py
+++ b/API/users/tests/test_merge_sort.py
@@ -1,0 +1,43 @@
+from users.merge_sort import merge_sort
+
+
+def test_ordena_scores_em_ordem_decrescente():
+    """Ordena os scores em ordem decrescente."""
+    candidates = [
+        {"id": 1, "score": 72},
+        {"id": 2, "score": 95},
+        {"id": 3, "score": 40},
+        {"id": 4, "score": 88},
+    ]
+
+    result = merge_sort(candidates, key=lambda candidate: candidate["score"], reverse=True)
+
+    assert [candidate["id"] for candidate in result] == [2, 4, 1, 3]
+
+
+def test_mantem_estabilidade_para_scores_empatados():
+    """Mantém a estabilidade para scores empatados."""
+    candidates = [
+        {"id": 1, "score": 80},
+        {"id": 2, "score": 90},
+        {"id": 3, "score": 80},
+        {"id": 4, "score": 70},
+    ]
+
+    result = merge_sort(candidates, key=lambda candidate: candidate["score"], reverse=True)
+
+    assert [candidate["id"] for candidate in result] == [2, 1, 3, 4]
+
+
+def test_lista_vazia():
+    """Funciona corretamente quando a lista é vazia."""
+    assert merge_sort([], reverse=True) == []
+
+
+def test_lista_com_unico_elemento():
+    """Funciona corretamente quando há um único score."""
+    candidates = [{"id": 1, "score": 100}]
+
+    result = merge_sort(candidates, key=lambda candidate: candidate["score"], reverse=True)
+
+    assert result == candidates


### PR DESCRIPTION

## Descrição

Este PR integra o algoritmo **Merge Sort** genérico e estável desenvolvido anteriormente (na pasta `Ordenacao_AcheiUnB`) no core da API (`API/users`). Juntamente com o algoritmo, foi incorporado o **Módulo de Ranking de Matches**, substituindo a listagem simples anterior por uma listagem **ordenada por similaridade**.

Isso melhora significativamente a experiência do usuário, pois agora as notificações de matches (itens perdidos vs encontrados) exibirão primeiro os candidatos mais prováveis, baseados em um cálculo inteligente de pontuação.

## Contexto

Anteriormente, o `match.py` simplesmente pegava todos os itens com a mesma categoria e localização e calculava a Distância de Hamming do código de barras, listando-os sem uma ordem de relevância refinada. 

Com essa feature, implementamos um cálculo de similaridade (de 0 a 100) que pondera:
- **Nome do item** (40% de peso - Similaridade de Jaccard)
- **Descrição** (25% de peso - Similaridade de Jaccard)
- **Cor** (15% de peso - Correspondência exata)
- **Marca** (15% de peso - Correspondência exata)
- **Proximidade da Data** (5% de peso - Quanto mais próxima, maior a nota)

Somente os candidatos que alcançam a nota mínima de corte (`min_score = 36`) são considerados matches. Essa lista final é ordenada pelo algoritmo de ordenação estável **Merge Sort**, do maior score para o menor.

## O que foi feito?

### Novos Módulos

*   **`API/users/merge_sort.py`**: Implementação do Merge Sort genérico e estável. Suporta ordenação crescente e decrescente através de funções `key` customizáveis.
*   **`API/users/match_ranking.py`**: Módulo que aplica os pesos, calcula o score final de cada candidato (`calculate_similarity_score`), filtra com base na nota de corte e chama o Merge Sort (`rank_match_candidates`).

### Refatoração

*   **`API/users/match.py`**: Modificado para importar a função `get_ranked_items` de `match_ranking.py`.
    *   No fluxo de itens perdidos (`lost`): a lista de matches candidata passa pelo filtro/ranqueamento antes de ser associada ao item.
    *   No fluxo de itens encontrados (`found`): cada item perdido correspondente tem sua lista de matches re-ranqueada com o novo candidato antes da notificação.

###  Testes Automatizados

Criamos uma suíte completa de testes no diretório `API/users/tests/`:
*   **`test_merge_sort.py` (4 testes)**: Garante a ordenação decrescente, estabilidade (para elementos empatados), tratamento de lista vazia e de lista com elemento único.
*   **`test_match_ranking.py` (9 testes)**: Valida a normalização de texto, o cálculo textual (Jaccard), cálculo booleano categórico (cor/marca), decaimento de score por datas e assegura que a ordenação respeita a regra da filtragem (`min_score = 36`).
*   **Total:** 13/13 novos testes passando.

##  Como testar?

1. Fazer o checkout para a branch da feature.
2. Ativar o ambiente virtual: `source .venv/bin/activate`
3. Acessar a pasta raiz do repositório: `cd /home/euller/2024-2-AcheiUnB`
4. Rodar os novos testes específicos:
   ```bash
   PYTHONPATH=/home/euller/2024-2-AcheiUnB/API:$PYTHONPATH python -m pytest API/users/tests/test_merge_sort.py API/users/tests/test_match_ranking.py -v
   ```
5. *(Opcional)* Você pode criar um item Perdido e um Achado parecidos via Swagger/Interface e conferir se o e-mail de match chega ordenado do mais provável para o menos provável.
